### PR TITLE
Update build script to include Prisma generate command

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
-    "build": "tsc",
+    "build": "prisma generate && tsc",
     "start": "node dist/index.js"
   },
   "keywords": [],

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,28 +1,27 @@
+generator client {
+  provider      = "prisma-client-js"
+  binaryTargets = ["native", "debian-openssl-3.0.x"]
+}
 
-    generator client {
-      provider = "prisma-client-js"
-    }
-    
-    datasource db {
-      provider = "sqlite"
-      url      = "file:./dev.db"
-    }
-    
-    model User {
-      id        Int           @id @default(autoincrement())
-      email     String        @unique
-      password  String
-      name      String?
-      createdAt DateTime      @default(now())
-      chats     ChatMessage[] // one-to-many relation
-    }
-    
-    model ChatMessage {
-      id        Int      @id @default(autoincrement())
-      prompt    String
-      reply     String
-      createdAt DateTime @default(now())
-      userId    Int?
-      user      User?    @relation(fields: [userId], references: [id])
-    }
-    
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
+
+model User {
+  id        Int           @id @default(autoincrement())
+  email     String        @unique
+  password  String
+  name      String?
+  createdAt DateTime      @default(now())
+  chats     ChatMessage[] // one-to-many relation
+}
+
+model ChatMessage {
+  id        Int      @id @default(autoincrement())
+  prompt    String
+  reply     String
+  createdAt DateTime @default(now())
+  userId    Int?
+  user      User?    @relation(fields: [userId], references: [id])
+}


### PR DESCRIPTION
Incorporate the `prisma generate` command into the build script to ensure the Prisma client is generated before building the project. This change enhances the build process by automating client generation.