### PR TITLE
- Instead of deploying using ssh deployed using docker hub

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,4 +1,4 @@
-name: Deploy EgyptoAI Backend
+name: Build and Deploy EgyptoAI Backend
 
 on:
   push:
@@ -6,13 +6,31 @@ on:
       - main
 
 jobs:
-  deploy:
+  build-and-push:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/egyptoai-backend:latest
+
+  deploy:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+
+    steps:
       - name: Set up SSH
         uses: webfactory/ssh-agent@v0.9.0
         with:
@@ -21,8 +39,8 @@ jobs:
       - name: Deploy via SSH
         run: |
           ssh -o StrictHostKeyChecking=no root@95.217.217.35 << 'EOF'
-            cd /root/egyptoai-backend
-            git pull origin main
-            docker compose down
-            docker compose up --build -d
+            docker pull ${{ secrets.DOCKERHUB_USERNAME }}/egyptoai-backend:latest
+            docker stop egyptoai-backend || true
+            docker rm egyptoai-backend || true
+            docker run -d --name egyptoai-backend --restart always -p 3000:3000 --env-file /root/egyptoai-backend/.env ${{ secrets.DOCKERHUB_USERNAME }}/egyptoai-backend:latest
           EOF


### PR DESCRIPTION
# Summary

This PR updates the deployment workflow to use Docker Hub instead of deploying directly via SSH. Now, the backend is built and pushed as a Docker image to Docker Hub, and the server pulls and runs the latest image.

## What Changed

- Added Docker Hub login and build/push steps to the GitHub Actions workflow.
- Deployment now pulls the latest Docker image and runs it using `docker run`.
- Removed direct `git pull` and `docker compose` commands from the server.
- The deployment process is now more streamlined and uses containerization best practices.

## Why

- Improves deployment reliability and consistency.
- Makes it easier to manage and roll back deployments.
- Leverages Docker Hub for image storage and versioning.

## How to Test

- Push to the `main` branch and check that the workflow builds, pushes, and deploys the Docker image successfully.
- Confirm the backend is running as a Docker container on the server.

Let me know if you have any questions or suggestions!